### PR TITLE
[add] sendMail, 認証コード関連機能、ResponseUtilクラス、Thymeleaf追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'

--- a/src/main/java/com/hanyahunya/gitRemind/AppConfig.java
+++ b/src/main/java/com/hanyahunya/gitRemind/AppConfig.java
@@ -1,24 +1,31 @@
 package com.hanyahunya.gitRemind;
 
+import com.hanyahunya.gitRemind.infrastructure.email.SendEmailService;
+import com.hanyahunya.gitRemind.infrastructure.email.SendEmailServiceImpl;
 import com.hanyahunya.gitRemind.member.repository.MemberRepository;
 import com.hanyahunya.gitRemind.member.repository.MemberRepositoryImpl;
-import com.hanyahunya.gitRemind.member.service.JwtTokenService;
-import com.hanyahunya.gitRemind.member.service.MemberService;
-import com.hanyahunya.gitRemind.member.service.MemberServiceImpl;
-import com.hanyahunya.gitRemind.member.service.TokenService;
+import com.hanyahunya.gitRemind.member.service.*;
 import com.hanyahunya.gitRemind.security.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.thymeleaf.TemplateEngine;
 
 import javax.sql.DataSource;
 
 @Configuration
 public class AppConfig {
     private final DataSource dataSource;
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
 
     @Autowired
-    public AppConfig(DataSource dataSource) {this.dataSource = dataSource;}
+    public AppConfig(DataSource dataSource, JavaMailSender javaMailSender, TemplateEngine templateEngine) {this.dataSource = dataSource;
+        this.javaMailSender = javaMailSender;
+        this.templateEngine = templateEngine;
+    }
 
     @Bean
     public MemberService memberService() {
@@ -33,5 +40,15 @@ public class AppConfig {
     @Bean
     public TokenService tokenService() {
         return new JwtTokenService();
+    }
+
+    @Bean
+    public SendEmailService sendEmailService() {
+        return new SendEmailServiceImpl(javaMailSender, templateEngine);
+    }
+
+    @Bean
+    public AuthCodeService authCodeService() {
+        return new AuthCodeServiceImpl(sendEmailService());
     }
 }

--- a/src/main/java/com/hanyahunya/gitRemind/infrastructure/email/SendEmailService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/infrastructure/email/SendEmailService.java
@@ -1,0 +1,8 @@
+package com.hanyahunya.gitRemind.infrastructure.email;
+
+import java.util.Map;
+
+public interface SendEmailService {
+
+    boolean sendEmail(String toEmail, String subject, String templateName, Map<String, Object> variables);
+}

--- a/src/main/java/com/hanyahunya/gitRemind/infrastructure/email/SendEmailServiceImpl.java
+++ b/src/main/java/com/hanyahunya/gitRemind/infrastructure/email/SendEmailServiceImpl.java
@@ -1,0 +1,44 @@
+package com.hanyahunya.gitRemind.infrastructure.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.util.Map;
+
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public class SendEmailServiceImpl implements SendEmailService {
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    @Override
+    public boolean sendEmail(String toEmail, String subject, String templateName, Map<String, Object> variables) {
+        Context context = new Context();
+        variables.forEach(context::setVariable);
+        String html = templateEngine.process(templateName, context);
+
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+            messageHelper.setFrom(fromEmail);
+            messageHelper.setTo(toEmail);
+            messageHelper.setSubject(subject);
+            messageHelper.setText(html, true);
+            mailSender.send(message);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+
+    }
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/controller/AuthController.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.hanyahunya.gitRemind.member.controller;
+
+import com.hanyahunya.gitRemind.util.ResponseDto;
+import com.hanyahunya.gitRemind.member.dto.EmailRequestDto;
+import com.hanyahunya.gitRemind.member.dto.ValidateCodeRequestDto;
+import com.hanyahunya.gitRemind.member.service.AuthCodeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static com.hanyahunya.gitRemind.util.ResponseUtil.toResponse;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class AuthController {
+    private final AuthCodeService authCodeService;
+
+    @PostMapping("/send-code")
+    public ResponseEntity<ResponseDto<Void>> sendAuthCode(@RequestBody @Valid EmailRequestDto emailRequestDto) {
+        ResponseDto<Void> responseDto = authCodeService.sendAuthCode(emailRequestDto);
+        return toResponse(responseDto);
+    }
+
+    @PostMapping("/validate-code")
+    public ResponseEntity<ResponseDto<Void>> validateAuthCode(@RequestBody @Valid ValidateCodeRequestDto validateCodeRequestDto) {
+        ResponseDto<Void> responseDto = authCodeService.validateAuthCode(validateCodeRequestDto);
+        return toResponse(responseDto);
+    }
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/controller/MemberController.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.hanyahunya.gitRemind.member.controller;
 
-import com.hanyahunya.gitRemind.ResponseDto;
-import com.hanyahunya.gitRemind.member.dto.JoinRequestDto;
-import com.hanyahunya.gitRemind.member.dto.JwtResponseDto;
-import com.hanyahunya.gitRemind.member.dto.LoginRequestDto;
-import com.hanyahunya.gitRemind.member.dto.MemberInfoResponseDto;
+import com.hanyahunya.gitRemind.util.ResponseDto;
+import com.hanyahunya.gitRemind.member.dto.*;
+import com.hanyahunya.gitRemind.member.service.AuthCodeService;
 import com.hanyahunya.gitRemind.member.service.MemberService;
 import com.hanyahunya.gitRemind.security.UserPrincipal;
 import jakarta.validation.Valid;
@@ -17,35 +15,35 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import static com.hanyahunya.gitRemind.util.ResponseUtil.toResponse;
+
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/member")
 public class MemberController {
     private final MemberService memberService;
+    private final AuthCodeService authCodeService;
 
     @PostMapping("/join")
     public ResponseEntity<ResponseDto<JwtResponseDto>> join(@RequestBody @Valid JoinRequestDto joinRequestDto) {
         ResponseDto<JwtResponseDto> responseDto = memberService.join(joinRequestDto);
-        return response(responseDto);
+        return toResponse(responseDto);
     }
 
     @PostMapping("/login")
     public ResponseEntity<ResponseDto<JwtResponseDto>> login(@RequestBody @Valid LoginRequestDto loginRequestDto) {
         ResponseDto<JwtResponseDto> responseDto = memberService.login(loginRequestDto);
-        return response(responseDto);
+        return toResponse(responseDto);
     }
 
     @GetMapping("/info")
     public ResponseEntity<ResponseDto<MemberInfoResponseDto>> memberInfo(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         ResponseDto<MemberInfoResponseDto> responseDto = memberService.getInfo(userPrincipal.getMid());
-        return response(responseDto);
+        return toResponse(responseDto);
     }
-
-    private <T> ResponseEntity<ResponseDto<T>> response(ResponseDto<T> responseDto) {
-        if (responseDto.isSuccess()) {
-            return ResponseEntity.ok().body(responseDto);
-        } else {
-            return ResponseEntity.badRequest().body(responseDto);
-        }
+    @GetMapping("/test")
+    public ResponseEntity<ResponseDto<Void>> test(@RequestBody @Valid EmailRequestDto emailRequestDto) {
+        ResponseDto<Void> responseDto = authCodeService.sendAuthCode(emailRequestDto);
+        return toResponse(responseDto);
     }
 }

--- a/src/main/java/com/hanyahunya/gitRemind/member/dto/EmailRequestDto.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/dto/EmailRequestDto.java
@@ -1,0 +1,11 @@
+package com.hanyahunya.gitRemind.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class EmailRequestDto {
+    @NotNull
+    private String email;
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/dto/ValidateCodeRequestDto.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/dto/ValidateCodeRequestDto.java
@@ -1,0 +1,12 @@
+package com.hanyahunya.gitRemind.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ValidateCodeRequestDto {
+    @NotNull
+    private String email;
+    @NotNull
+    private String authCode;
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeService.java
@@ -1,0 +1,18 @@
+package com.hanyahunya.gitRemind.member.service;
+
+import com.hanyahunya.gitRemind.util.ResponseDto;
+import com.hanyahunya.gitRemind.member.dto.EmailRequestDto;
+import com.hanyahunya.gitRemind.member.dto.ValidateCodeRequestDto;
+
+public interface AuthCodeService {
+    /**
+     * emailを基づいてメールを送る
+     */
+    ResponseDto<Void> sendAuthCode(EmailRequestDto emailRequestDto);
+
+    /**
+     * メールアドレスと認証コードを基づいて認証結果をreturn
+     * @param validateCodeRequestDto email, authCode必須
+     */
+    ResponseDto<Void> validateAuthCode(ValidateCodeRequestDto validateCodeRequestDto);
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeServiceImpl.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeServiceImpl.java
@@ -1,0 +1,79 @@
+package com.hanyahunya.gitRemind.member.service;
+
+import com.hanyahunya.gitRemind.util.ResponseDto;
+import com.hanyahunya.gitRemind.infrastructure.email.SendEmailService;
+import com.hanyahunya.gitRemind.member.dto.EmailRequestDto;
+import com.hanyahunya.gitRemind.member.dto.ValidateCodeRequestDto;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@RequiredArgsConstructor
+public class AuthCodeServiceImpl implements AuthCodeService {
+    private final SendEmailService sendEmailService;
+
+    // Synchronized Map
+    private final Map<String, String> authCodeMap = new ConcurrentHashMap<>();
+    private ScheduledExecutorService schedule;
+    private final AtomicBoolean isSchedulerCreated = new AtomicBoolean(false);
+    private final SecureRandom random = new SecureRandom();
+
+    @PostConstruct // Line39のNullPointExceptionを防ぐため
+    public void init() {
+        schedule = Executors.newScheduledThreadPool(1);
+        schedule.shutdown();
+    }
+
+    @Override
+    public ResponseDto<Void> sendAuthCode(EmailRequestDto emailRequestDto) {
+        String email = emailRequestDto.getEmail();
+
+        // スケジューラがない場合、スレッドを作る　+　原子単位のBooleanでシンクロを合わせる
+        if(schedule.isShutdown() && isSchedulerCreated.compareAndSet(false, true)) {
+            schedule = Executors.newScheduledThreadPool(1);
+        }
+
+        String authCode = String.valueOf(random.nextInt(900000) + 100000);
+        authCodeMap.put(email, authCode);
+
+        //　3分後に実行されるスケジュールを作る（最後のemailが消されたら、スレッドを停止）
+        schedule.schedule(() -> {
+            authCodeMap.remove(email);
+            if(authCodeMap.isEmpty()) {
+                schedule.shutdown();
+                isSchedulerCreated.set(false);
+            }
+        }, 3, TimeUnit.MINUTES);
+
+        //　ThymeleafのHtmlにパラメータを入れる
+        Map<String, Object> params = new HashMap<>();
+        params.put("code", authCode);
+        boolean success = sendEmailService.sendEmail(email, "gitRemind AuthCode", "test", params);
+        if(success) {
+            return ResponseDto.success("認証コード発信成功");
+        } else {
+            return ResponseDto.fail("認証コード発信失敗");
+        }
+    }
+
+    @Override
+    public ResponseDto<Void> validateAuthCode(ValidateCodeRequestDto validateCodeRequestDto) {
+        String email = validateCodeRequestDto.getEmail();
+        String authCode = validateCodeRequestDto.getAuthCode();
+        boolean equals = authCode.equals(authCodeMap.get(email));
+        if(equals) {
+            authCodeMap.remove(email);
+            return ResponseDto.success("認証コード一致");
+        } else {
+            return ResponseDto.fail("認証コード不一致");
+        }
+    }
+}

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/MemberService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.hanyahunya.gitRemind.member.service;
 
-import com.hanyahunya.gitRemind.ResponseDto;
+import com.hanyahunya.gitRemind.util.ResponseDto;
 import com.hanyahunya.gitRemind.member.dto.JoinRequestDto;
 import com.hanyahunya.gitRemind.member.dto.JwtResponseDto;
 import com.hanyahunya.gitRemind.member.dto.LoginRequestDto;
@@ -25,4 +25,10 @@ public interface MemberService {
      * @return MemberInfoResponseDto.email, .git_addr
      */
     ResponseDto<MemberInfoResponseDto> getInfo(String mid);
+
+    ResponseDto<Void> resetPassword();
+
+    ResponseDto<Void> deleteMember();
+
+    ResponseDto<Void> updateMember();
 }

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/MemberServiceImpl.java
@@ -1,6 +1,6 @@
 package com.hanyahunya.gitRemind.member.service;
 
-import com.hanyahunya.gitRemind.ResponseDto;
+import com.hanyahunya.gitRemind.util.ResponseDto;
 import com.hanyahunya.gitRemind.member.dto.JoinRequestDto;
 import com.hanyahunya.gitRemind.member.dto.JwtResponseDto;
 import com.hanyahunya.gitRemind.member.dto.LoginRequestDto;
@@ -9,7 +9,6 @@ import com.hanyahunya.gitRemind.member.entity.Member;
 import com.hanyahunya.gitRemind.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -48,5 +47,20 @@ public class MemberServiceImpl implements MemberService {
                         ResponseDto.success("ユーザー情報ロード成功", MemberInfoResponseDto.set(member.getEmail(), member.getGit_addr()))
                 )
                 .orElseGet(() -> ResponseDto.fail("ユーザー情報ロード失敗"));
+    }
+
+    @Override
+    public ResponseDto<Void> resetPassword() {
+        return null;
+    }
+
+    @Override
+    public ResponseDto<Void> deleteMember() {
+        return null;
+    }
+
+    @Override
+    public ResponseDto<Void> updateMember() {
+        return null;
     }
 }

--- a/src/main/java/com/hanyahunya/gitRemind/security/SecurityConfig.java
+++ b/src/main/java/com/hanyahunya/gitRemind/security/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/member/join", "/member/login").permitAll() // 認証なしにアクセス可能
+                                .requestMatchers("/member/join", "/member/login", "/member/send-code"
+                                        , "/member/validate-code").permitAll() // 認証なしにアクセス可能
                                 .anyRequest().authenticated() // 他のリクエストは認証必要
                 )
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/hanyahunya/gitRemind/util/ResponseDto.java
+++ b/src/main/java/com/hanyahunya/gitRemind/util/ResponseDto.java
@@ -1,4 +1,4 @@
-package com.hanyahunya.gitRemind;
+package com.hanyahunya.gitRemind.util;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/hanyahunya/gitRemind/util/ResponseUtil.java
+++ b/src/main/java/com/hanyahunya/gitRemind/util/ResponseUtil.java
@@ -1,0 +1,17 @@
+package com.hanyahunya.gitRemind.util;
+
+import org.springframework.http.ResponseEntity;
+
+public class ResponseUtil {
+    private ResponseUtil() {
+        throw new UnsupportedOperationException("このクラスはインスタンス化できません");
+    }
+
+    public static <T> ResponseEntity<ResponseDto<T>> toResponse(ResponseDto<T> responseDto) {
+        if (responseDto.isSuccess()) {
+            return ResponseEntity.ok(responseDto);
+        } else {
+            return ResponseEntity.badRequest().body(responseDto);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,14 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=${GIT_REMIND_DB_URL}
 spring.datasource.username=${GIT_REMIND_DB_USERNAME}
 spring.datasource.password=${GIT_REMIND_DB_PW}
+
+spring.mail.host=${SPRING_MAIL_HOST}
+spring.mail.port=${SPRING_MAIL_PORT}
+spring.mail.username=${SPRING_MAIL_USERNAME}
+spring.mail.password=${SPRING_MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+
+spring.mail.protocol=smtps
+spring.mail.properties.mail.smtp.ssl.enable=true
+spring.mail.properties.mail.smtp.ssl.trust=${SPRING_MAIL_HOST}

--- a/src/main/resources/templates/test.html
+++ b/src/main/resources/templates/test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>認証コード</title>
+</head>
+<body>
+<p>次の認証コードをご入力してください:</p>
+<div style="font-size:24px; font-weight:bold; color:blue;">
+    <span th:text="${code}"></span>
+</div>
+</body>
+</html>


### PR DESCRIPTION
コントローラーでのResponseEntity<ResponseDto<?>>の応答は、ResponseUtilクラスの(static)toResponseメソッドを利用