### PR TITLE
[add] 全てのトークン発行をTokenCookieHeaderGeneratorで管理するよう変更

### DIFF
--- a/src/main/java/com/hanyahunya/gitRemind/AppConfig.java
+++ b/src/main/java/com/hanyahunya/gitRemind/AppConfig.java
@@ -65,7 +65,7 @@ public class AppConfig {
     }
     @Bean
     public AuthCodeService authCodeService() {
-        return new AuthCodeServiceImpl(sendEmailService());
+        return new AuthCodeServiceImpl(sendEmailService(), pwTokenService());
     }
     // ここまでmemberパッケージ
 
@@ -95,8 +95,8 @@ public class AppConfig {
         return new JwtRefreshTokenService();
     }
     @Bean
-    public PwTokenService pwTokenService() {
-        return new JwtPwTokenService();
+    public EmailValidateTokenService pwTokenService() {
+        return new JwtEmailValidateTokenService();
     }
     @Bean
     public SecurityAlertEmailService securityAlertEmailService() {

--- a/src/main/java/com/hanyahunya/gitRemind/member/controller/MemberController.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/controller/MemberController.java
@@ -27,7 +27,8 @@ public class MemberController {
     private final TokenCookieHeaderGenerator tokenCookieHeaderGenerator;
 
     @PostMapping("/join")
-    public ResponseEntity<ResponseDto<Void>> join(@RequestBody @Valid JoinRequestDto joinRequestDto) {
+    public ResponseEntity<ResponseDto<Void>> join(@RequestBody @Valid JoinRequestDto joinRequestDto, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        joinRequestDto.setEmail(userPrincipal.getEmail());
         ResponseDto<Void> responseDto = memberService.join(joinRequestDto);
         return toResponse(responseDto);
     }

--- a/src/main/java/com/hanyahunya/gitRemind/member/dto/JoinRequestDto.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/dto/JoinRequestDto.java
@@ -1,5 +1,6 @@
 package com.hanyahunya.gitRemind.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hanyahunya.gitRemind.member.entity.Member;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -12,7 +13,7 @@ public class JoinRequestDto {
     private String loginId;
     @NotNull
     private String password;
-    @NotNull
+    @JsonIgnore
     private String email;
     private String country;
 

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/AuthCodeService.java
@@ -4,6 +4,7 @@ import com.hanyahunya.gitRemind.token.service.TokenPurpose;
 import com.hanyahunya.gitRemind.util.ResponseDto;
 import com.hanyahunya.gitRemind.member.dto.EmailRequestDto;
 import com.hanyahunya.gitRemind.member.dto.ValidateCodeRequestDto;
+import com.hanyahunya.gitRemind.util.cookieHeader.SetResultDto;
 
 public interface AuthCodeService {
     /**
@@ -15,5 +16,5 @@ public interface AuthCodeService {
      * メールアドレスと認証コードを基づいて認証結果をreturn
      * @param validateCodeRequestDto email, authCode必須
      */
-    ResponseDto<Void> validateAuthCode(ValidateCodeRequestDto validateCodeRequestDto, TokenPurpose tokenPurpose);
+    SetResultDto validateAuthCode(ValidateCodeRequestDto validateCodeRequestDto, TokenPurpose tokenPurpose);
 }

--- a/src/main/java/com/hanyahunya/gitRemind/member/service/PasswordServiceImpl.java
+++ b/src/main/java/com/hanyahunya/gitRemind/member/service/PasswordServiceImpl.java
@@ -30,11 +30,8 @@ public class PasswordServiceImpl implements PasswordService {
                     .password(resetPwRequestDto.getNewPassword())
                     .build();
             if(memberRepository.updateMember(member)) {
-                if (tokenService.deleteTokenAtAllDevice(member.getMemberId()).isSuccess()) {
-                    return ResponseDto.success("パスワード更新成功");
-                } else {
-                    throw new RuntimeException("TokenService.deleteTokenAtAllDevice failed");
-                }
+                tokenService.deleteTokenAtAllDevice(member.getMemberId());
+                return ResponseDto.success("パスワード更新成功");
             }
         }
         return ResponseDto.fail("パスワード更新失敗");

--- a/src/main/java/com/hanyahunya/gitRemind/security/EmailValidateAuthFilter.java
+++ b/src/main/java/com/hanyahunya/gitRemind/security/EmailValidateAuthFilter.java
@@ -1,7 +1,8 @@
 package com.hanyahunya.gitRemind.security;
 
-import com.hanyahunya.gitRemind.token.service.PwTokenService;
+import com.hanyahunya.gitRemind.token.service.EmailValidateTokenService;
 import com.hanyahunya.gitRemind.token.service.TokenPurpose;
+import com.hanyahunya.gitRemind.util.cookieHeader.TokenCookieHeaderGenerator;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,7 +10,9 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,10 +24,13 @@ import java.time.Duration;
 
 @Component
 @RequiredArgsConstructor
-public class EmailVerificationFilter extends OncePerRequestFilter {
+public class EmailValidateAuthFilter extends OncePerRequestFilter {
     private final StringRedisTemplate redisTemplate;
-    private final PwTokenService pwTokenService;
+    private final EmailValidateTokenService emailValidateTokenService;
+    private final TokenCookieHeaderGenerator tokenCookieHeaderGenerator;
 
+    @Value("${jwt.validateToken.expiration}")
+    private long expirationTime;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -52,12 +58,13 @@ public class EmailVerificationFilter extends OncePerRequestFilter {
             return;
         }
         Claims claims = null;
+
         try {
-            if (resetPasswordToken != null) {
-                claims = pwTokenService.getClaims(resetPasswordToken);
+            if (resetPasswordToken != null && uri.startsWith("/member/reset-password")) {
+                claims = emailValidateTokenService.getClaims(resetPasswordToken);
             }
-            if (emailVerificationToken != null) {
-                claims = pwTokenService.getClaims(emailVerificationToken);
+            if (emailVerificationToken != null && uri.startsWith("/member/join")) {
+                claims = emailValidateTokenService.getClaims(emailVerificationToken);
             }
         } catch (Exception e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -67,19 +74,24 @@ public class EmailVerificationFilter extends OncePerRequestFilter {
         String purpose = claims.get("purpose", String.class);
         String email = claims.get("email", String.class);
 
+        String deleteValidateToken = null;
         if (uri.startsWith("/member/reset-password") && purpose.equals(TokenPurpose.RESET_PASSWORD.name().toLowerCase())) {
             verifyAndAuthenticate(resetPasswordToken, email);
+            deleteValidateToken = tokenCookieHeaderGenerator.deleteValidateToken(TokenPurpose.RESET_PASSWORD);
         }
         if (uri.startsWith("/member/join") && purpose.equals(TokenPurpose.EMAIL_VERIFICATION.name().toLowerCase())) {
             verifyAndAuthenticate(emailVerificationToken, email);
+            deleteValidateToken = tokenCookieHeaderGenerator.deleteValidateToken(TokenPurpose.EMAIL_VERIFICATION);
         }
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteValidateToken);
+
         filterChain.doFilter(request, response);
     }
 
     private void verifyAndAuthenticate(String token, String email) {
         String prefix = "blacklist:";
         if (!redisTemplate.hasKey(prefix + token)) {
-             Boolean added = redisTemplate.opsForValue().setIfAbsent(prefix + token, "blacklisted", Duration.ofMinutes(5));
+             Boolean added = redisTemplate.opsForValue().setIfAbsent(prefix + token, "blacklisted", Duration.ofMillis(expirationTime));
              if (Boolean.TRUE.equals(added)) {
                  UserPrincipal userPrincipal = new UserPrincipal(null, null, email);
                  Authentication auth = new UsernamePasswordAuthenticationToken(userPrincipal, null, null);

--- a/src/main/java/com/hanyahunya/gitRemind/security/SecurityConfig.java
+++ b/src/main/java/com/hanyahunya/gitRemind/security/SecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAccessAuthFilter jwtAccessAuthFilter;
-    private final EmailVerificationFilter emailVerificationFilter;
+    private final EmailValidateAuthFilter emailValidateAuthFilter;
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
@@ -35,8 +35,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         final String[] whitelist = {
-                "/member/join", "/member/login",
-                "/auth-code", "/auth-code/validate", "/auth-code/validate/password-code",
+                "/member/login",
+                "/auth-code", "/auth-code/validate", "auth-code/password-code", "/auth-code/validate/password-code",
                 "/refreshAccessToken"
         };
 
@@ -50,7 +50,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS設定適用
                 .csrf(AbstractHttpConfigurer::disable) // CSRF保護未使用
                 .addFilterBefore(jwtAccessAuthFilter, UsernamePasswordAuthenticationFilter.class) // JWT追加
-                .addFilterBefore(emailVerificationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(emailValidateAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/hanyahunya/gitRemind/token/service/EmailValidateTokenService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/token/service/EmailValidateTokenService.java
@@ -2,7 +2,7 @@ package com.hanyahunya.gitRemind.token.service;
 
 import io.jsonwebtoken.Claims;
 
-public interface PwTokenService {
+public interface EmailValidateTokenService {
     String generateToken(String email, TokenPurpose purpose);
 
     boolean validateToken(String token);

--- a/src/main/java/com/hanyahunya/gitRemind/token/service/JwtEmailValidateTokenService.java
+++ b/src/main/java/com/hanyahunya/gitRemind/token/service/JwtEmailValidateTokenService.java
@@ -1,7 +1,6 @@
 package com.hanyahunya.gitRemind.token.service;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -10,8 +9,8 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
-public class JwtPwTokenService implements PwTokenService {
-    @Value("${jwt.pwToken.secret}")
+public class JwtEmailValidateTokenService implements EmailValidateTokenService {
+    @Value("${jwt.validateToken.secret}")
     private String jwtKey;
 
     private SecretKey key;
@@ -21,7 +20,7 @@ public class JwtPwTokenService implements PwTokenService {
         key = Keys.hmacShaKeyFor(jwtKey.getBytes(StandardCharsets.UTF_8));
     }
 
-    @Value("${jwt.pwToken.expiration}")
+    @Value("${jwt.validateToken.expiration}")
     private long expirationTime;
 
     @Override

--- a/src/main/java/com/hanyahunya/gitRemind/util/cookieHeader/SetResultDto.java
+++ b/src/main/java/com/hanyahunya/gitRemind/util/cookieHeader/SetResultDto.java
@@ -1,5 +1,6 @@
 package com.hanyahunya.gitRemind.util.cookieHeader;
 
+import com.hanyahunya.gitRemind.token.service.TokenPurpose;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,7 +15,13 @@ public class SetResultDto {
     @Builder.Default
     private String refreshToken  = null;
     @Builder.Default
+    private String validateToken = null;
+    @Builder.Default
+    private TokenPurpose purpose = null;
+    @Builder.Default
     private boolean deleteAccessToken = false;
     @Builder.Default
     private boolean deleteRefreshToken = false;
+    @Builder.Default
+    private boolean deleteValidateToken = false;
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,7 @@ jwt.accessToken.expiration=900000
 jwt.refreshToken.secret=${GIT_REMIND_JWT_REFRESH_KEY}
 jwt.refreshToken.expiration=604800000
 #5min
-jwt.pwToken.secret=${GIT_REMIND_JWT_PASSWORD_KEY}
-jwt.pwToken.expiration=300000
+jwt.validateToken.secret=${GIT_REMIND_JWT_PASSWORD_KEY}
+jwt.validateToken.expiration=300000
 
 password.encoder.secret=${GIT_REMIND_ENCODER_KEY}


### PR DESCRIPTION
トークンの使い捨て化をメール認証関連全てのトークンに適用